### PR TITLE
Fix assistants client initialization and related docs/tests

### DIFF
--- a/api/server/services/Endpoints/assistants/index.js
+++ b/api/server/services/Endpoints/assistants/index.js
@@ -1,6 +1,6 @@
 const addTitle = require('./title');
 const buildOptions = require('./build');
-const initializeClient = require('./initalize');
+const initializeClient = require('./initialize');
 
 module.exports = {
   addTitle,

--- a/api/server/services/Endpoints/assistants/initialize.js
+++ b/api/server/services/Endpoints/assistants/initialize.js
@@ -42,7 +42,7 @@ const initializeClient = async ({ req, res, endpointOption, version, initAppClie
     ...endpointOption,
   };
 
-  if (userProvidesKey & !apiKey) {
+  if (userProvidesKey && !apiKey) {
     throw new Error(
       JSON.stringify({
         type: ErrorTypes.NO_USER_KEY,

--- a/api/server/services/Endpoints/assistants/initialize.spec.js
+++ b/api/server/services/Endpoints/assistants/initialize.spec.js
@@ -2,7 +2,7 @@
 const { ProxyAgent } = require('undici');
 const { ErrorTypes } = require('librechat-data-provider');
 const { getUserKey, getUserKeyExpiry, getUserKeyValues } = require('~/server/services/UserService');
-const initializeClient = require('./initalize');
+const initializeClient = require('./initialize');
 // const { OpenAIClient } = require('~/app');
 
 jest.mock('~/server/services/UserService', () => ({

--- a/api/server/services/domains.js
+++ b/api/server/services/domains.js
@@ -24,13 +24,8 @@ function isEmailDomainAllowed(email, allowedDomains) {
 }
 
 /**
- * Normalizes a domain string
- * @param {string} domain
- * @returns {string|null}
- */
-/**
- * Normalizes a domain string. If the domain is invalid, returns null.
- * Normalized === lowercase, trimmed, and protocol added if missing.
+ * Normalizes a domain string. Returns the domain hostname lowercased and trimmed, or null if invalid.
+ * Protocol is added temporarily for parsing but removed from the returned hostname.
  * @param {string} domain
  * @returns {string|null}
  */

--- a/client/src/components/Auth/__tests__/Login.spec.tsx
+++ b/client/src/components/Auth/__tests__/Login.spec.tsx
@@ -172,7 +172,7 @@ test('calls loginUser.mutate on login', async () => {
   await userEvent.type(passwordInput, 'password');
   await userEvent.click(submitButton);
 
-  waitFor(() => expect(mutate).toHaveBeenCalled());
+  await waitFor(() => expect(mutate).toHaveBeenCalled());
 });
 
 test('Navigates to / on successful login', async () => {
@@ -202,5 +202,5 @@ test('Navigates to / on successful login', async () => {
   await userEvent.type(passwordInput, 'password');
   await userEvent.click(submitButton);
 
-  waitFor(() => expect(history.location.pathname).toBe('/'));
+  await waitFor(() => expect(history.location.pathname).toBe('/'));
 });


### PR DESCRIPTION
## Summary
- rename the assistants endpoint helper to `initialize` so imports reference the correctly spelled file
- guard missing user-provided API keys with logical checks in the assistants client initializer
- clarify `normalizeDomain` documentation to describe the normalized hostname result
- await async `waitFor` assertions in the login spec to ensure the login mutation and redirect are observed

## Testing
- `npm run test:ci -- Login.spec.tsx` *(fails: Cannot find module 'librechat-data-provider' from 'src/hooks/AuthContext.tsx')*

------
https://chatgpt.com/codex/tasks/task_b_68d5523a9ad88322b2d255dced5199fc